### PR TITLE
python3 support + backwards compatibility

### DIFF
--- a/kdrama_dl.command
+++ b/kdrama_dl.command
@@ -87,10 +87,20 @@ if [ -z $resolution ]; then
     exit 1
 fi
 
+# checking for version of python, macOS 12.3+ python2 is removed in favor of python3
+python_version=$(python -c "import sys; print(sys.version_info.major)" 2>/dev/null)
+if [ $? -ne 0 ]; then
+  python_version="3"
+fi
+
 # URL escape resolution param so that we can use values like "720p+"
 # python is available by default on MacOS - comment out if
 # using urlencoded params
-resolution=$(python3 -c "import urllib.parse; print(urllib.parse.quote('''$resolution'''))")
+if [ $python_version="3"  ]; then
+  resolution=$(python3 -c "import urllib.parse; print(urllib.parse.quote('''$resolution'''))")
+else
+  resolution=$(python -c "import urllib; print(urllib.quote('''$resolution'''))")
+fi
 
 echo -e "Choose a ${C_OKBLUE}File Format${C_END} (enter the option number)":
 select ext in 'mkv' 'mp4'; do

--- a/kdrama_dl.command
+++ b/kdrama_dl.command
@@ -90,7 +90,7 @@ fi
 # URL escape resolution param so that we can use values like "720p+"
 # python is available by default on MacOS - comment out if
 # using urlencoded params
-resolution=$(python -c "import urllib; print(urllib.quote('''$resolution'''))")
+resolution=$(python3 -c "import urllib.parse; print(urllib.parse.quote('''$resolution'''))")
 
 echo -e "Choose a ${C_OKBLUE}File Format${C_END} (enter the option number)":
 select ext in 'mkv' 'mp4'; do


### PR DESCRIPTION
macOS version tested on: 12.4 (Monterey)
python version: 3.8.9

Starting from macOS 12.3+ python2 is removed in favor of python3, inputting the resolution will print this error:

```
/Users/*******/Downloads/kdrama1/kdrama_dl.command: line 104: python: command not found
```

```bash
~ $ /Users/*******/Downloads/kdrama1/kdrama_dl.command ; exit;
*** A new downloader script version is available. Please reinstall from https://github.com/lastmodified/kdrama_dl.command ***
[i] Using FFMPEG path: /Users/*******/Downloads/kdrama1/ffmpeg 
ffmpeg version 3.4.2-tessus Copyright (c) 2000-2018 the FFmpeg developers

kdrama_dl.command: version 1.0.2
To exit/abort the script at any time, enter [CONTROL+C].
--------------------------------------------------------
Enter Download Code: #####
The resolution must be available on the video page. Please check before entering.
Enter Resolution (ex: 1080p, 720p, 480p, 360p): 1080p
/Users/*******/Downloads/kdrama1/kdrama_dl.command: line 104: python: command not found
Choose a File Format (enter the option number):
1) mkv
2) mp4
#? ^C
Interrupt detected. Download aborted.
```

Adding backwards compatibility to support older macs which have python2 installed
- check the major version of python installed with `python -c "import sys; print(sys.version_info.major)"`
  - if it errors out we can assume the machine only uses python3
- if v3, will set `resolution` to `python3 -c "import urllib.parse; print(urllib.parse.quote('''$resolution'''))"`
- if v2, will set `resolution` to `python -c "import urllib; print(urllib.quote('''$resolution'''))"`